### PR TITLE
Prohibit defining the same API method twice

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -782,11 +782,13 @@ API.prototype.declare = function(options, handler) {
     options.output = this._options.schemaPrefix + options.output;
   }
   this._entries.push(options);
-  var valueArr = values.map(function(item){ return item.name });
-  var isDuplicate = valueArr.some(function(item, idx){ 
-   return valueArr.indexOf(item) != idx 
-});
-throw “This function has already been declared”;
+  var valueArr = options.map((item) => {return item.name});
+  var isDuplicate = valueArr.some(function(item , idx){ 
+    return valueArr.indexOf(item) != idx 
+  });
+  if (isDuplicate) {
+    throw new Error('This function has already been declared');
+  }
 };
 
 /**


### PR DESCRIPTION
Added changes to the "declare" function of api.js by using the some and map prototype to check for two methods in the array that have the same `name` property. Throws an error if this is the case.